### PR TITLE
Fix Mixin errors

### DIFF
--- a/src/main/java/steve_gall/minecolonies_compatibility/core/common/building/module/BucketFillingCraftingModule.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/core/common/building/module/BucketFillingCraftingModule.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.NotNull;
 
-import com.lothrazar.cyclic.util.FluidHelpers.FluidAttributes;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -122,7 +122,7 @@ public class BucketFillingCraftingModule extends AbstractCraftingModuleWithExter
 
 		if (recipe != null)
 		{
-			return Component.translatable("minecolonies_compatibility.interaction.no_fluid_source", recipe.getFluidStack(FluidAttributes.BUCKET_VOLUME).getDisplayName());
+			return Component.translatable("minecolonies_compatibility.interaction.no_fluid_source", recipe.getFluidStack(FluidType.BUCKET_VOLUME).getDisplayName());
 		}
 
 		return this.getWorkingBlockNotFoundMessage();
@@ -171,7 +171,7 @@ public class BucketFillingCraftingModule extends AbstractCraftingModuleWithExter
 
 				if (fluidHandler != null)
 				{
-					var stack = recipe.getFluidStack(FluidAttributes.BUCKET_VOLUME);
+					var stack = recipe.getFluidStack(FluidType.BUCKET_VOLUME);
 					var drained = fluidHandler.drain(stack, simulate ? FluidAction.SIMULATE : FluidAction.EXECUTE);
 					return drained.getAmount() >= stack.getAmount();
 				}

--- a/src/main/java/steve_gall/minecolonies_compatibility/core/common/crafting/BucketFillingCraftingType.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/core/common/crafting/BucketFillingCraftingType.java
@@ -3,10 +3,10 @@ package steve_gall.minecolonies_compatibility.core.common.crafting;
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.lothrazar.cyclic.util.FluidHelpers.FluidAttributes;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.registry.CraftingType;
 
@@ -34,7 +34,7 @@ public class BucketFillingCraftingType extends CraftingType
 
 	public static BucketFillingRecipeStorage parse(ItemStack filledBucket)
 	{
-		var tank = new FluidTank(FluidAttributes.BUCKET_VOLUME);
+		var tank = new FluidTank(FluidType.BUCKET_VOLUME);
 		var emptyResult = FluidUtil.tryEmptyContainer(filledBucket, tank, tank.getCapacity(), null, true);
 		var emptyBucket = emptyResult.getResult();
 

--- a/src/main/java/steve_gall/minecolonies_compatibility/mixin/client/minecolonies/WindowListRecipes1Mixin.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/mixin/client/minecolonies/WindowListRecipes1Mixin.java
@@ -2,6 +2,7 @@ package steve_gall.minecolonies_compatibility.mixin.client.minecolonies;
 
 import java.util.ArrayList;
 
+import net.minecraftforge.fluids.FluidType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.views.View;
-import com.lothrazar.cyclic.util.FluidHelpers.FluidAttributes;
 import com.minecolonies.api.util.constant.WindowConstants;
 import com.minecolonies.core.client.gui.modules.WindowListRecipes;
 
@@ -69,7 +69,7 @@ public abstract class WindowListRecipes1Mixin
 						view.addChild(fluidIcon);
 					}
 
-					fluidIcon.setFluid(bucketFilling.getFluidStack(FluidAttributes.BUCKET_VOLUME));
+					fluidIcon.setFluid(bucketFilling.getFluidStack(FluidType.BUCKET_VOLUME));
 				}
 
 			}

--- a/src/main/java/steve_gall/minecolonies_compatibility/mixin/common/MineColoniesCompatibilityMixinPlugin.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/mixin/common/MineColoniesCompatibilityMixinPlugin.java
@@ -1,0 +1,79 @@
+package steve_gall.minecolonies_compatibility.mixin.common;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraftforge.fml.loading.FMLLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import steve_gall.minecolonies_compatibility.module.common.ModuleManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class MineColoniesCompatibilityMixinPlugin implements IMixinConfigPlugin
+{
+    private static boolean isModPresent(String id)
+    {
+        return FMLLoader.getLoadingModList().getModFileById(id) != null;
+    }
+
+    private static final Supplier<Boolean> TRUE = () -> true;
+
+    private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
+            "steve_gall.minecolonies_compatibility.mixin.common.blue_skies.BrewberryBushBlockAccessor", () -> isModPresent(ModuleManager.BLUE_SKIES.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.cobblemon.BerryBlockAccessor", () -> isModPresent(ModuleManager.COBBLEMON.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.cyclic.AppleCropBlockAccessor", () -> isModPresent(ModuleManager.CYCLIC.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.oreberries.OreBerryBushBlockAccessor", () -> isModPresent(ModuleManager.OREBERRIES.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.reliquary.HandgunItemAccessor", () -> isModPresent(ModuleManager.RELIQUARY.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.reliquary.NeutralShotEntityMixin", () -> isModPresent(ModuleManager.RELIQUARY.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.storagenetwork.NetworkModuleAccessor", () -> isModPresent(ModuleManager.STORAGE_NETWORK.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.storagenetwork.UtilConnectionsMixin", () -> isModPresent(ModuleManager.STORAGE_NETWORK.getModId()),
+            "steve_gall.minecolonies_compatibility.mixin.common.thermal.CropBlockCoFHAccessor", () -> isModPresent(ModuleManager.THERMAL.getModId())
+    );
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName)
+    {
+        return CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
+    }
+
+    // Unused
+
+    @Override
+    public void onLoad(String mixinPackage)
+    {
+
+    }
+
+    @Override
+    public String getRefMapperConfig()
+    {
+        return "";
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets)
+    {
+
+    }
+
+    @Override
+    public List<String> getMixins()
+    {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo)
+    {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo)
+    {
+
+    }
+}

--- a/src/main/java/steve_gall/minecolonies_compatibility/mixin/common/minecolonies/GenericRecipeCategoryMixin.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/mixin/common/minecolonies/GenericRecipeCategoryMixin.java
@@ -1,5 +1,6 @@
 package steve_gall.minecolonies_compatibility.mixin.common.minecolonies;
 
+import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -9,7 +10,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.lothrazar.cyclic.util.FluidHelpers.FluidAttributes;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.core.compatibility.jei.GenericRecipeCategory;
@@ -68,8 +68,8 @@ public abstract class GenericRecipeCategoryMixin extends JobBasedRecipeCategory<
 		if (recipe instanceof BucketFillingGenericRecipe fillingRecipe)
 		{
 			var slot = builder.addSlot(RecipeIngredientRole.INPUT, this.outputSlotX, CITIZEN_Y + 1);
-			slot.addFluidStack(fillingRecipe.getFluid(), FluidAttributes.BUCKET_VOLUME, fillingRecipe.getFluidTag());
-			slot.setFluidRenderer(FluidAttributes.BUCKET_VOLUME, false, 16, 16);
+			slot.addFluidStack(fillingRecipe.getFluid(), FluidType.BUCKET_VOLUME, fillingRecipe.getFluidTag());
+			slot.setFluidRenderer(FluidType.BUCKET_VOLUME, false, 16, 16);
 			slot.setBackground(this.slot, -1, -1);
 		}
 

--- a/src/main/resources/data/minecolonies_compatibility/recipes/crafting/citizen_inventory.json
+++ b/src/main/resources/data/minecolonies_compatibility/recipes/crafting/citizen_inventory.json
@@ -1,5 +1,11 @@
 {
 	"type": "minecraft:crafting_shaped",
+	"conditions": [
+		{
+			"type": "forge:item_exists",
+			"item": "minecolonies_compatibility:citizen_inventory"
+		}
+	],
 	"pattern": [
 		"dkd",
 		"kck",

--- a/src/main/resources/minecolonies_compatibility.mixin.common.json
+++ b/src/main/resources/minecolonies_compatibility.mixin.common.json
@@ -3,6 +3,7 @@
 	"package": "steve_gall.minecolonies_compatibility.mixin.common",
 	"minVersion": "0.8.5",
 	"compatibilityLevel": "JAVA_17",
+	"plugin": "steve_gall.minecolonies_compatibility.mixin.common.MineColoniesCompatibilityMixinPlugin",
 	"mixins": [
 		"minecraft.BlockEntityMixin",
 		"minecraft.CropBlockAccessor",


### PR DESCRIPTION
Hi! This PR fixes Mixin errors that could have been observed in the log on startup if soft dependencies are missing, additionally I have noticed the mod has been injecting Cyclic's code into base MineColonies, when it is a soft dependency, which is also fixed. The best practice with Mixins, when you mixin into the code of a soft dependency is to have `IMixinConfigPlugin`, so that you can prevent Mixin from applying based on certain conditions. Feel free to object.