### PR TITLE
Bug Fix: NullPointerException in CitizenTerminalPart

### DIFF
--- a/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/CitizenTerminalPart.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/CitizenTerminalPart.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
@@ -971,7 +972,10 @@ public class CitizenTerminalPart extends AbstractDisplayPart implements IStorage
 	@Override
 	public ImmutableSet<ICraftingLink> getRequestedJobs()
 	{
-		return ImmutableSet.copyOf(this.view.tasks.values().stream().map(taskHolder -> taskHolder.getCraftingLink()).toArray(ICraftingLink[]::new));
+		return this.view.tasks.values().stream()
+			.map(taskHolder -> taskHolder.getCraftingLink())
+			.filter(Objects::nonNull)
+			.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@Override

--- a/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/CitizenTerminalPart.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/CitizenTerminalPart.java
@@ -972,10 +972,10 @@ public class CitizenTerminalPart extends AbstractDisplayPart implements IStorage
 	@Override
 	public ImmutableSet<ICraftingLink> getRequestedJobs()
 	{
-		return this.view.tasks.values().stream()
-			.map(taskHolder -> taskHolder.getCraftingLink())
-			.filter(Objects::nonNull)
-			.collect(ImmutableSet.toImmutableSet());
+		return this.view.tasks.values().stream()//
+				.map(TaskHolder::getCraftingLink)//
+				.filter(Objects::nonNull)//
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@Override


### PR DESCRIPTION
## 🐛 Bug Fix: NullPointerException in CitizenTerminalPart

### Description
Fixes a crash that occurs when AE2 initializes a `CableBusBlockEntity` containing a `CitizenTerminalPart`. The crash happens during server startup or when the block entity is loaded.

### Problem
The `getRequestedJobs()` method was attempting to create an `ImmutableSet` from a collection that could contain `null` values. Guava's `ImmutableSet.copyOf()` throws a `NullPointerException` when it encounters null elements.

**Error:** 
java.lang.NullPointerException: Readying AE2 block entity
at com.google.common.collect.ImmutableSet.copyOf(ImmutableSet.java:300)
at steve_gall.minecolonies_compatibility.module.common.ae2.CitizenTerminalPart.getRequestedJobs(CitizenTerminalPart.java:975)


### Root Cause
The `taskHolder.getCraftingLink()` method can return `null` for tasks that haven't been linked yet or have been cancelled. The previous implementation didn't filter out these null values before creating the immutable set.

### Solution
- Added `Objects` import for null-safe filtering
- Refactored the stream pipeline to filter out null values using `Objects::nonNull`
- Changed from `ImmutableSet.copyOf()` to `.collect(ImmutableSet.toImmutableSet())` for cleaner stream handling
