### PR TITLE
Fix AE2 menu double registration

### DIFF
--- a/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/init/ModuleMenuTypes.java
+++ b/src/main/java/steve_gall/minecolonies_compatibility/module/common/ae2/init/ModuleMenuTypes.java
@@ -20,7 +20,7 @@ public class ModuleMenuTypes
 
 	private static <MENU extends AEBaseMenu> DeferredHolder<MenuType<?>, MenuType<MENU>> register(String name, Supplier<MenuTypeBuilder<MENU, ?>> builderSupplier)
 	{
-		return REGISTER.register(name, () -> builderSupplier.get().build(name));
+		return REGISTER.register(name, () -> builderSupplier.get().buildUnregistered(MineColoniesCompatibility.rl(name)));
 	}
 
 	private ModuleMenuTypes()


### PR DESCRIPTION
 Before this change, startup with AE2 19.2.17 failed during menu registration:

 ```Java
java.lang.IllegalStateException: Adding duplicate value 'net.minecraft.world.inventory.MenuType@27f0b69c' to registry
    at net.minecraft.core.MappedRegistry.register(MappedRegistry.java:141)
    at net.minecraft.core.Registry.register(Registry.java:123)
    at appeng.init.InitMenuTypes.registerAll(InitMenuTypes.java:118)
    at appeng.init.InitMenuTypes.init(InitMenuTypes.java:71)
    at appeng.core.AppEngBase.lambda$new$0(AppEngBase.java:154)
 ```

The `MenuType@...` identity was varied between runs.

This change allowed both mods to start! 

 MineColonies Compatibility 3.53

 Jar: MineColonies_Compatibility-1.21.1-3.53.jar

 Minecraft 1.21.1, NeoForge.